### PR TITLE
Fix DasErste, WDR and ZDF Mediathek to new website layout and m3u8 parsing

### DIFF
--- a/SiteUtilProjects/OnlineVideos.Sites.offbyone/DasErsteMediathekUtil.cs
+++ b/SiteUtilProjects/OnlineVideos.Sites.offbyone/DasErsteMediathekUtil.cs
@@ -6,28 +6,64 @@ using System.Web;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace OnlineVideos.Sites
-{    
+{
+    public class JsonResponse
+    {
+        [JsonProperty("_type")]
+        public string Type { get; set; }
+        [JsonProperty("_isLive")]
+        public bool IsLive { get; set; }
+        [JsonProperty("_defaultQuality")]
+        public object[] DefaultQuality { get; set; }
+        public string _previewImage { get; set; }
+        public int _subtitleOffset { get; set; }
+        [JsonProperty("_mediaArray")]
+        public Mediaarray[] MediaArray { get; set; }
+    }
+
+    public class Mediaarray
+    {
+        public int _plugin { get; set; }
+        [JsonProperty("_mediaStreamArray")]
+        public Mediastreamarray[] MediaStreamArray { get; set; }
+    }
+
+    public class Mediastreamarray
+    {
+        [JsonProperty("_quality")]
+        public string Quality { get; set; }
+        [JsonProperty("_server")]
+        public string Server { get; set; }
+        [JsonProperty("_cdn")]
+        public string Cdn { get; set; }
+        [JsonProperty("_stream")]
+        public object Stream { get; set; }
+    }
     public class DasErsteMediathekUtil : SiteUtilBase
-    {        
+    {
         public enum VideoQuality { Low, Med, High, HD };
+        string m3u8Regex1 = @"#EXT-X-STREAM-INF:CODECS=""(?<codecs>[^""]+)"",BANDWIDTH=(?<bitrate>\d+).*?\n(?<url>.*)";
+        string m3u8Regex2 = @"#EXT-X-STREAM-INF:PROGRAM-ID=\d,BANDWIDTH=(?<bitrate>\d+),?RESOLUTION=(?<resolution>\d+x\d+),?CODECS=""(?<codecs>[^""]+)"".*?\n(?<url>.*)";
 
-        [Category("OnlineVideosUserConfiguration"), LocalizableDisplayName("Video Quality", TranslationFieldName="VideoQuality"), Description("Choose your preferred quality for the videos according to bandwidth.")]
-        VideoQuality videoQuality = VideoQuality.High;
 
-		string nextPageUrl;
+        [Category("OnlineVideosUserConfiguration"), LocalizableDisplayName("Video Quality", TranslationFieldName = "VideoQuality"), Description("Choose your preferred quality for the videos according to bandwidth.")]
+        VideoQuality videoQuality = VideoQuality.HD;
 
-		public override int DiscoverDynamicCategories()
-		{
-			Settings.Categories.Add(new RssLink() { Name = "Sendungen A-Z", HasSubCategories = true, Url = "http://www.ardmediathek.de/tv/sendungen-a-z" });
-			Settings.Categories.Add(new RssLink() { Name = "Sendung verpasst?", HasSubCategories = true, Url = "http://www.ardmediathek.de/tv/sendungVerpasst" });
+        string nextPageUrl;
+
+        public override int DiscoverDynamicCategories()
+        {
             Settings.Categories.Add(new RssLink() { Name = "TV-Livestreams", Url = "http://www.ardmediathek.de/tv/live" });
+            Settings.Categories.Add(new RssLink() { Name = "Sendung verpasst?", HasSubCategories = true, Url = "http://www.ardmediathek.de/tv/sendungVerpasst" });
+            Settings.Categories.Add(new RssLink() { Name = "Sendungen A-Z", HasSubCategories = true, Url = "http://www.ardmediathek.de/tv/sendungen-a-z" });
 
-			Uri baseUri = new Uri("http://www.ardmediathek.de/tv");
-			var baseDoc = GetWebData<HtmlDocument>(baseUri.AbsoluteUri);
-			foreach (var modHeadline in baseDoc.DocumentNode.Descendants("h2").Where(h2 => h2.GetAttributeValue("class", "") == "modHeadline"))
-			{
+            Uri baseUri = new Uri("http://www.ardmediathek.de/tv");
+            var baseDoc = GetWebData<HtmlDocument>(baseUri.AbsoluteUri);
+            foreach (var modHeadline in baseDoc.DocumentNode.Descendants("h2").Where(h2 => h2.GetAttributeValue("class", "") == "modHeadline"))
+            {
                 var title = HttpUtility.HtmlDecode(string.Join("", modHeadline.Elements("#text").Select(t => t.InnerText.Trim()).ToArray()));
                 if (!title.ToLower().Contains("live"))
                 {
@@ -43,10 +79,10 @@ namespace OnlineVideos.Sites
                         Settings.Categories.Add(cat);
                     }
                 }
-			}
-			Settings.DynamicCategoriesDiscovered = true;
-			return Settings.Categories.Count;
-		}
+            }
+            Settings.DynamicCategoriesDiscovered = true;
+            return Settings.Categories.Count;
+        }
 
         bool SubItemsAreVideos(HtmlNode parentNode)
         {
@@ -62,294 +98,355 @@ namespace OnlineVideos.Sites
             return false;
         }
 
-		void GetSubcategoriesFromDiv(RssLink parentCategory, HtmlNode mainDiv)
-		{
-			var myBaseUri = new Uri((parentCategory as RssLink).Url);
-			foreach (var teaser in mainDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
-			{
-				RssLink subCategory = new RssLink() { ParentCategory = parentCategory };
-				var img = teaser.Descendants("img").FirstOrDefault();
-				if (img != null) subCategory.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
-				var headline = teaser.Descendants("h4").FirstOrDefault(h4 => h4.GetAttributeValue("class", "") == "headline");
-				if (headline != null) subCategory.Name = HttpUtility.HtmlDecode(headline.InnerText.Trim());
-				var link = teaser.Descendants("a").FirstOrDefault();
-				if (link != null) subCategory.Url = new Uri(myBaseUri, HttpUtility.HtmlDecode(link.GetAttributeValue("href", ""))).AbsoluteUri;
+        void GetSubcategoriesFromDiv(RssLink parentCategory, HtmlNode mainDiv)
+        {
+            var myBaseUri = new Uri((parentCategory as RssLink).Url);
+            foreach (var teaser in mainDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
+            {
+                RssLink subCategory = new RssLink() { ParentCategory = parentCategory };
+                var img = teaser.Descendants("img").FirstOrDefault();
+                if (img != null) subCategory.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
+                var headline = teaser.Descendants("h4").FirstOrDefault(h4 => h4.GetAttributeValue("class", "") == "headline");
+                if (headline != null) subCategory.Name = HttpUtility.HtmlDecode(headline.InnerText.Trim());
+                var link = teaser.Descendants("a").FirstOrDefault();
+                if (link != null) subCategory.Url = new Uri(myBaseUri, HttpUtility.HtmlDecode(link.GetAttributeValue("href", ""))).AbsoluteUri;
 
-				var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
-				if (textWrapper != null)
-				{
-					var subtitle = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle");
-					if (subtitle != null) subCategory.Description = subtitle.InnerText;
-				}
+                var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
+                if (textWrapper != null)
+                {
+                    var subtitle = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle");
+                    if (subtitle != null) subCategory.Description = subtitle.InnerText;
+                }
 
-				parentCategory.SubCategories.Add(subCategory);
-			}
-		}
+                parentCategory.SubCategories.Add(subCategory);
+            }
+        }
 
-		public override int DiscoverSubCategories(Category parentCategory)
-		{
-			parentCategory.SubCategories = new List<Category>();
-			var myBaseUri = new Uri((parentCategory as RssLink).Url);
-			var baseDoc = GetWebData<HtmlDocument>(myBaseUri.AbsoluteUri);
+        public override int DiscoverSubCategories(Category parentCategory)
+        {
+            parentCategory.SubCategories = new List<Category>();
+            var myBaseUri = new Uri((parentCategory as RssLink).Url);
+            var baseDoc = GetWebData<HtmlDocument>(myBaseUri.AbsoluteUri);
 
-			if (parentCategory.Name == "Sendungen A-Z")
-			{	
-				foreach (HtmlNode entry in baseDoc.DocumentNode.Descendants("ul").FirstOrDefault(ul => ul.GetAttributeValue("class", "") == "subressorts raster").Elements("li"))
-				{
-					var a = entry.Descendants("a").FirstOrDefault();
-					RssLink letter = new RssLink() { Name = a.InnerText.Trim(), ParentCategory = parentCategory, HasSubCategories = true, SubCategories = new List<Category>() };
-					if (!string.IsNullOrEmpty(a.GetAttributeValue("href", "")))
-					{
-						letter.Url = new Uri(myBaseUri, a.GetAttributeValue("href", "")).AbsoluteUri;
-						parentCategory.SubCategories.Add(letter);
-					}
-				}
-				parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
-			}
-			else if (parentCategory.Name == "Sendung verpasst?")
-			{
-				var senderDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modSender"))
-					.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
-				foreach (HtmlNode entry in senderDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active"))
-				{
-					var a = entry.Descendants("a").FirstOrDefault();
-					if (a != null && a.GetAttributeValue("href", "") != "#")
-					{
-						parentCategory.SubCategories.Add(new RssLink()
-						{
-							Name = a.InnerText.Trim(),
-							Url = new Uri(myBaseUri, a.GetAttributeValue("href", "")).AbsoluteUri,
-							ParentCategory = parentCategory,
-							HasSubCategories = true,
-							SubCategories = new List<Category>()
-						});
-					}
-				}
-				parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
-			}
+            if (parentCategory.Name == "Sendungen A-Z")
+            {
+                foreach (HtmlNode entry in baseDoc.DocumentNode.Descendants("ul").FirstOrDefault(ul => ul.GetAttributeValue("class", "") == "subressorts raster").Elements("li"))
+                {
+                    var a = entry.Descendants("a").FirstOrDefault();
+                    RssLink letter = new RssLink() { Name = a.InnerText.Trim(), ParentCategory = parentCategory, HasSubCategories = true, SubCategories = new List<Category>() };
+                    if (!string.IsNullOrEmpty(a.GetAttributeValue("href", "")))
+                    {
+                        letter.Url = new Uri(myBaseUri, a.GetAttributeValue("href", "")).AbsoluteUri;
+                        parentCategory.SubCategories.Add(letter);
+                    }
+                }
+                parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
+            }
+            else if (parentCategory.Name == "Sendung verpasst?")
+            {
+                var senderDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modSender"))
+                    .Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
+                foreach (HtmlNode entry in senderDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active"))
+                {
+                    var a = entry.Descendants("a").FirstOrDefault();
+                    if (a != null && a.GetAttributeValue("href", "") != "#")
+                    {
+                        var tvStation = CreateRssLinkFromAnchor(a, myBaseUri, parentCategory);
+                        tvStation.HasSubCategories = true;
+                        tvStation.SubCategories = new List<Category>();
+                        parentCategory.SubCategories.Add(tvStation);
+                    }
+                }
+                parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
+            }
             else if (parentCategory.ParentCategory == null || parentCategory.ParentCategory.Name == "Sendungen A-Z")
-			{
-				var mainDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "elementWrapper")
-					.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "boxCon");
-				GetSubcategoriesFromDiv(parentCategory as RssLink, mainDiv);
-				parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
-			}
-			else if (parentCategory.ParentCategory.Name == "Sendung verpasst?")
-			{
-				var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modProgramm"))
-					.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
-				foreach (HtmlNode entry in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active").Skip(1))
-				{
-					var a = entry.Descendants("a").FirstOrDefault();
-                    var day = new RssLink() { Name = a.InnerText.Trim(), Url = new Uri(myBaseUri, HttpUtility.HtmlDecode(a.GetAttributeValue("href", ""))).AbsoluteUri, ParentCategory = parentCategory };
-					var j = HttpUtility.HtmlDecode(entry.GetAttributeValue("data-ctrl-programmloader-source", ""));
-					if (!string.IsNullOrEmpty(j))
-					{
-						var f = JObject.Parse(j);
-						day.Name += " " + HttpUtility.UrlDecode(f.Value<string>("pixValue")).Split('/')[1];
-					}
-					parentCategory.SubCategories.Add(day);
-				}
-			}
-			
-			return parentCategory.SubCategories.Count;
-		}
+            {
+                var mainDivs = baseDoc.DocumentNode.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "elementWrapper").Select(elem => elem.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "boxCon")).ToList();
+                var mainDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "elementWrapper")
+                    .Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "boxCon");
+                GetSubcategoriesFromDiv(parentCategory as RssLink, mainDiv);
+                parentCategory.SubCategoriesDiscovered = parentCategory.SubCategories.Count > 0;
+            }
+            else if (parentCategory.ParentCategory.Name == "Sendung verpasst?")
+            {
+                var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modProgramm"))
+                    .Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
+                foreach (HtmlNode entry in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active").Skip(1))
+                {
+                    var a = entry.Descendants("a").FirstOrDefault();
+                    var dayLink = CreateRssLinkFromAnchor(a, myBaseUri, parentCategory);
+                    var j = HttpUtility.HtmlDecode(entry.GetAttributeValue("data-ctrl-programmloader-source", ""));
+                    if (!string.IsNullOrWhiteSpace(j))
+                    {
+                        var f = JObject.Parse(j);
+                        dayLink.Name += " " + HttpUtility.UrlDecode(f.Value<string>("pixValue")).Split('/')[1];
+                    }
+                    parentCategory.SubCategories.Add(dayLink);
+                }
+
+                parentCategory.SubCategories.Reverse();
+            }
+
+            return parentCategory.SubCategories.Count;
+        }
+
+        private static RssLink CreateRssLinkFromAnchor(HtmlNode a, Uri myBaseUri, Category parentCategory)
+        {
+            var name = string.Join("", a.ChildNodes.Where(elem => elem.GetAttributeValue("class", "") != "hidden").Select(elem => elem.InnerHtml.Trim()));
+            var rssLink = new RssLink()
+            {
+                Name = name,
+                Url = new Uri(myBaseUri, HttpUtility.HtmlDecode(a.GetAttributeValue("href", ""))).AbsoluteUri,
+                ParentCategory = parentCategory
+            };
+            return rssLink;
+        }
 
         public override List<VideoInfo> GetVideos(Category category)
         {
-			HasNextPage = false;
+            HasNextPage = false;
 
-			var myBaseUri = new Uri((category as RssLink).Url);
-			var baseDoc = GetWebData<HtmlDocument>(myBaseUri.AbsoluteUri);
+            var myBaseUri = new Uri((category as RssLink).Url);
+            var baseDoc = GetWebData<HtmlDocument>(myBaseUri.AbsoluteUri);
 
-			var result = new List<VideoInfo>();
-			if (category.Name == "TV-Livestreams")
-			{
-				var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modSender"))
-					.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
-				foreach (HtmlNode entry in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active").Skip(1))
-				{
-					var a = entry.Descendants("a").FirstOrDefault();
-					if (a != null && a.GetAttributeValue("href","").Length > 1)
-					{
-						result.Add(new VideoInfo()
-						{
-							Title = a.InnerText.Trim(),
-							VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(a.GetAttributeValue("href", ""))).AbsoluteUri
-						});
-					}
-				}
-			}
-			else if (myBaseUri.AbsoluteUri.Contains("sendungVerpasst"))
-			{
-				var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modProgramm"));
-				foreach (var boxDiv in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "box"))
-				{
-					foreach (var entryDiv in boxDiv.Elements("div").FirstOrDefault().Elements("div").Where(div => div.GetAttributeValue("class", "") == "entry"))
-					{
-						var start = entryDiv.Descendants("span").FirstOrDefault(span => span.GetAttributeValue("class", "") == "date").InnerText;
-						var title = entryDiv.Descendants("span").FirstOrDefault(span => span.GetAttributeValue("class", "") == "titel").InnerText;
-						foreach (var teaser in entryDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
-						{
-							var video = new VideoInfo();
-							var img = teaser.Descendants("img").FirstOrDefault();
-							if (img != null) video.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
+            var result = new List<VideoInfo>();
+            if (category.Name == "TV-Livestreams")
+            {
+                var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modSender"))
+                    .Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("controls"));
+                foreach (HtmlNode entry in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "entry" || div.GetAttributeValue("class", "") == "entry active").Skip(1))
+                {
+                    var a = entry.Descendants("a").FirstOrDefault();
+                    if (a != null && a.GetAttributeValue("href", "").Length > 1)
+                    {
+                        result.Add(new VideoInfo()
+                        {
+                            Title = a.InnerText.Trim(),
+                            VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(a.GetAttributeValue("href", ""))).AbsoluteUri
+                        });
+                    }
+                }
+            }
+            else if (myBaseUri.AbsoluteUri.Contains("sendungVerpasst"))
+            {
+                var programmDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modProgramm"));
+                foreach (var boxDiv in programmDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "box"))
+                {
+                    foreach (var entryDiv in boxDiv.Elements("div").FirstOrDefault().Elements("div").Where(div => div.GetAttributeValue("class", "") == "entry"))
+                    {
+                        var start = entryDiv.Descendants("span").FirstOrDefault(span => span.GetAttributeValue("class", "") == "date").InnerText;
+                        var title = entryDiv.Descendants("span").FirstOrDefault(span => span.GetAttributeValue("class", "") == "titel").InnerText;
+                        foreach (var teaser in entryDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
+                        {
+                            var video = new VideoInfo();
+                            var img = teaser.Descendants("img").FirstOrDefault();
+                            if (img != null) video.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
 
-							var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
-							if (textWrapper != null)
-							{
-								video.VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(textWrapper.Element("a").GetAttributeValue("href", ""))).AbsoluteUri;
-								video.Title = textWrapper.Descendants("h4").FirstOrDefault().InnerText.Trim();
-								if (video.Title != title) video.Title = title + " - " + video.Title;
-								video.Length = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle").InnerText.Split('|')[0].Trim();
-								video.Airdate = start + " Uhr";
-								result.Add(video);
-							}
-						}
-					}
-				}
-			}
+                            var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
+                            if (textWrapper != null)
+                            {
+                                video.VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(textWrapper.Element("a").GetAttributeValue("href", ""))).AbsoluteUri;
+                                video.Title = textWrapper.Descendants("h4").FirstOrDefault().InnerText.Trim();
+                                if (video.Title != title) video.Title = title + " - " + video.Title;
+                                video.Length = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle").InnerText.Split('|')[0].Trim();
+                                video.Airdate = start + " Uhr";
+                                result.Add(video);
+                            }
+                        }
+                    }
+                }
+            }
             else if (myBaseUri.AbsoluteUri.Contains("/Video?"))
             {
                 return new List<VideoInfo>() { new VideoInfo() { Title = category.Name, VideoUrl = myBaseUri.AbsoluteUri, Description = category.Description, Thumb = category.Thumb } };
             }
-			else
-			{
-				var mainDiv = baseDoc.DocumentNode.Descendants("div").LastOrDefault(div => div.GetAttributeValue("class", "").Contains("modMini")).ParentNode;
-				result = GetVideosFromDiv(mainDiv, myBaseUri);
-			}
-			return result;
+            else
+            {
+                var mainDiv = baseDoc.DocumentNode.Descendants("div").LastOrDefault(div => div.GetAttributeValue("class", "").Contains("modMini")).ParentNode;
+                result = GetVideosFromDiv(mainDiv, myBaseUri);
+            }
+            return result;
         }
 
-		List<VideoInfo> GetVideosFromDiv(HtmlNode mainDiv, Uri myBaseUri)
-		{
-			var result = new List<VideoInfo>();
-			foreach (var teaser in mainDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
-			{
-				var link = teaser.Descendants("a").FirstOrDefault();
-				if (link != null)
-				{
-					var video = new VideoInfo();
-					video.VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(link.GetAttributeValue("href", ""))).AbsoluteUri;
+        List<VideoInfo> GetVideosFromDiv(HtmlNode mainDiv, Uri myBaseUri)
+        {
+            var result = new List<VideoInfo>();
+            foreach (var teaser in mainDiv.Descendants("div").Where(div => div.GetAttributeValue("class", "") == "teaser"))
+            {
+                var link = teaser.Descendants("a").FirstOrDefault();
+                if (link != null)
+                {
+                    var video = new VideoInfo();
+                    video.VideoUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(link.GetAttributeValue("href", ""))).AbsoluteUri;
                     if (!video.VideoUrl.Contains("/Video?"))
                         continue;
 
-					var img = teaser.Descendants("img").FirstOrDefault();
-					if (img != null) video.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
+                    var img = teaser.Descendants("img").FirstOrDefault();
+                    if (img != null) video.Thumb = new Uri(myBaseUri, JObject.Parse(HttpUtility.HtmlDecode(img.GetAttributeValue("data-ctrl-image", ""))).Value<string>("urlScheme").Replace("##width##", "256")).AbsoluteUri;
 
-					var headline = teaser.Descendants("h4").FirstOrDefault(h4 => h4.GetAttributeValue("class", "") == "headline");
-					if (headline != null) video.Title = HttpUtility.HtmlDecode(headline.InnerText.Trim());
+                    var headline = teaser.Descendants("h4").FirstOrDefault(h4 => h4.GetAttributeValue("class", "") == "headline");
+                    if (headline != null) video.Title = HttpUtility.HtmlDecode(headline.InnerText.Trim());
 
-					var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
-					if (textWrapper != null)
-					{
-						var dachzeile = HttpUtility.HtmlDecode(textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "dachzeile").InnerText);
-						video.Description = dachzeile;
+                    var textWrapper = teaser.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "") == "textWrapper");
+                    if (textWrapper != null)
+                    {
+                        var dachzeile = HttpUtility.HtmlDecode(textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "dachzeile").InnerText);
+                        video.Description = dachzeile;
 
-						var teaserParagraph = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "teasertext");
-						if (teaserParagraph != null)
-							video.Description += (string.IsNullOrEmpty(video.Description) ? "" : "\n") + teaserParagraph.InnerText;
+                        var teaserParagraph = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "teasertext");
+                        if (teaserParagraph != null)
+                            video.Description += (string.IsNullOrEmpty(video.Description) ? "" : "\n") + teaserParagraph.InnerText;
 
-						var subtitleNode = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle");
+                        var subtitleNode = textWrapper.Descendants("p").FirstOrDefault(div => div.GetAttributeValue("class", "") == "subtitle");
                         string subtitle = (subtitleNode != null && subtitleNode.ChildNodes.Count > 0) ? subtitleNode.ChildNodes[0].InnerText : "";
-						if (subtitle.Contains('|'))
-						{
-							
-							foreach (var subtitleSplit in subtitle.Split('|'))
-							{
-								if (subtitleSplit.Contains("min"))
-									video.Length = subtitleSplit.Trim();
-								else if (subtitleSplit.Count(c => c == '.') == 2)
-									video.Airdate = subtitleSplit.Trim();
-							}
-						}
-						else
-						{
-							video.Length = subtitle;
-							video.Airdate = dachzeile;
-						}
-					}
-					result.Add(video);
-				}
-			}
-			
-			// paging
-			var nextPageLink = mainDiv.Descendants("a").FirstOrDefault(a => a.GetAttributeValue("href", "") != "" && a.InnerText.Trim() == HttpUtility.HtmlEncode(">"));
-			HasNextPage = nextPageLink != null;
-			if (HasNextPage)
-				nextPageUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(nextPageLink.GetAttributeValue("href", ""))).AbsoluteUri;
+                        if (subtitle.Contains('|'))
+                        {
 
-			return result;
-		}
+                            foreach (var subtitleSplit in subtitle.Split('|'))
+                            {
+                                if (subtitleSplit.Contains("min"))
+                                    video.Length = subtitleSplit.Trim();
+                                else if (subtitleSplit.Count(c => c == '.') == 2)
+                                    video.Airdate = subtitleSplit.Trim();
+                            }
+                        }
+                        else
+                        {
+                            video.Length = subtitle;
+                            video.Airdate = dachzeile;
+                        }
+                    }
+                    result.Add(video);
+                }
+            }
 
-		public override List<VideoInfo> GetNextPageVideos()
-		{
-			var myBaseUri = new Uri(nextPageUrl);
-			var doc = GetWebData<HtmlDocument>(nextPageUrl);
-			var mainDiv = doc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modList") || div.GetAttributeValue("class", "").Contains("modMini")).ParentNode;
-			return GetVideosFromDiv(mainDiv, myBaseUri);
-		}
+            // paging
+            var nextPageLink = mainDiv.Descendants("a").FirstOrDefault(a => a.GetAttributeValue("href", "") != "" && a.InnerText.Trim() == HttpUtility.HtmlEncode(">"));
+            HasNextPage = nextPageLink != null;
+            if (HasNextPage)
+                nextPageUrl = new Uri(myBaseUri, HttpUtility.HtmlDecode(nextPageLink.GetAttributeValue("href", ""))).AbsoluteUri;
 
-		public override bool CanSearch { get { return true; } }
+            return result;
+        }
+
+        public override List<VideoInfo> GetNextPageVideos()
+        {
+            var myBaseUri = new Uri(nextPageUrl);
+            var doc = GetWebData<HtmlDocument>(nextPageUrl);
+            var mainDiv = doc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modList") || div.GetAttributeValue("class", "").Contains("modMini")).ParentNode;
+            return GetVideosFromDiv(mainDiv, myBaseUri);
+        }
+
+        public override bool CanSearch { get { return true; } }
 
         public override List<SearchResultItem> Search(string query, string category = null)
-		{
-			var searchUrl = string.Format("http://www.ardmediathek.de/tv/suche?searchText={0}", HttpUtility.UrlEncode(query));
-			var myBaseUri = new Uri(searchUrl);
-			var doc = GetWebData<HtmlDocument>(searchUrl);
-			var mainDiv = doc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modList")).ParentNode;
-			return GetVideosFromDiv(mainDiv, myBaseUri).ConvertAll(v => v as SearchResultItem);
-		}
+        {
+            var searchUrl = string.Format("http://www.ardmediathek.de/tv/suche?searchText={0}", HttpUtility.UrlEncode(query));
+            var myBaseUri = new Uri(searchUrl);
+            var doc = GetWebData<HtmlDocument>(searchUrl);
+            var mainDiv = doc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("class", "").Contains("modList")).ParentNode;
+            return GetVideosFromDiv(mainDiv, myBaseUri).ConvertAll(v => v as SearchResultItem);
+        }
 
         public override String GetVideoUrl(VideoInfo video)
         {
+            var cache = new List<string>();
             var baseDoc = GetWebData<HtmlDocument>(video.VideoUrl);
             var mediaDiv = baseDoc.DocumentNode.Descendants("div").FirstOrDefault(div => div.GetAttributeValue("data-ctrl-player", "") != "");
             if (mediaDiv != null)
             {
                 var configUrl = new Uri(new Uri(video.VideoUrl), JObject.Parse(HttpUtility.HtmlDecode(mediaDiv.GetAttributeValue("data-ctrl-player", ""))).Value<string>("mcUrl")).AbsoluteUri;
-                var mediaJson = GetWebData<JObject>(configUrl);
-                video.PlaybackOptions = new Dictionary<string, string>();
-                foreach (var media in mediaJson["_mediaArray"].SelectMany(m => m["_mediaStreamArray"]))
+                var mediaString = GetWebData<string>(configUrl);
+                var mediaJson = JsonConvert.DeserializeObject<JsonResponse>(mediaString);
+                var playbackOptionsByUrl = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var media in mediaJson.MediaArray.SelectMany(m => m.MediaStreamArray).Select(streamArray => new
+                    {
+                        Quality = int.TryParse(streamArray.Quality, out int qualityNumber) ? ((VideoQuality)qualityNumber).ToString() : "HD",
+                        Url = streamArray.Stream is JArray urlArray ? urlArray.Values<string>().OrderByDescending(item => item, StringComparer.OrdinalIgnoreCase).First() : streamArray.Stream as string,
+                        Server = streamArray.Server
+                    }).Distinct())
                 {
-                    var quali = ((JValue)media["_quality"]).Type == JTokenType.Integer ? ((VideoQuality)media.Value<int>("_quality")).ToString() : "HD";
-
-                    var url = media["_stream"] is JArray ? media["_stream"][0].Value<string>() : media.Value<string>("_stream");
-
-                    if (url.EndsWith(".smil")) url = GetStreamUrlFromSmil(url);
-
-                    if (Uri.IsWellFormedUriString(url, UriKind.Absolute))
+                    string url = media.Url;
+                    cache.Add(url);
+                    if (url.EndsWith(".smil"))
                     {
-                        if (url.EndsWith("f4m"))
-                            url += "?g=" + Helpers.StringUtils.GetRandomLetters(12) + "&hdcore=3.8.0";
-                        video.PlaybackOptions[quali] = url;
+                        url = GetStreamUrlFromSmil(url);
                     }
-                    else if (mediaJson.Value<bool>("_isLive"))
+
+                    if (Uri.IsWellFormedUriString(url, UriKind.RelativeOrAbsolute))
                     {
-                        var server = media.Value<string>("_server");
-                        var stream = media.Value<string>("_stream");
-                        url = "";
-                        if (string.IsNullOrEmpty(stream))
+                        if (Uri.IsWellFormedUriString(url, UriKind.Relative))
                         {
-                            string guessedStream = server.Substring(server.LastIndexOf('/') + 1);
-                            url = new MPUrlSourceFilter.RtmpUrl(server) { Live = true, LiveStream = true, Subscribe = guessedStream, PageUrl = video.VideoUrl }.ToString();
+                            var absoluteUri = new Uri(new Uri(video.VideoUrl), url);
+                            url = absoluteUri.ToString();
                         }
-                        else if (stream.Contains('?'))
+
+                        if (url.Contains("master.m3u8"))
                         {
-                            var tcUrl = server.TrimEnd('/') + stream.Substring(stream.IndexOf('?'));
-                            var app = new Uri(server).AbsolutePath.Trim('/') + stream.Substring(stream.IndexOf('?'));
-                            var playPath = stream;
+                            var m3u8Data = GetWebData(url);
+                            foreach (Match match in Regex.Matches(m3u8Data, m3u8Regex2))
+                            {
+                                playbackOptionsByUrl[match.Groups["url"].Value] =
+                                    string.Format("HLS - {0} - {1} kbps", match.Groups["resolution"].Value, int.Parse(match.Groups["bitrate"].Value) / 1000);
+                                cache.Add(match.Groups["url"].Value);
+                            }
+
+                            foreach (Match match in Regex.Matches(m3u8Data, m3u8Regex1))
+                            {
+                                playbackOptionsByUrl[match.Groups["url"].Value] =
+                                    string.Format("HLS - {0} - {1} kbps", match.Groups["codecs"].Value, int.Parse(match.Groups["bitrate"].Value) / 1000);
+                                cache.Add(match.Groups["url"].Value);
+                            }
+                        }
+                        else if (url.EndsWith("f4m"))
+                        {
+                            url += "?g=" + Helpers.StringUtils.GetRandomLetters(12) + "&hdcore=3.8.0";
+                            playbackOptionsByUrl[url] = media.Quality;
+                        }
+                        else
+                        {
+                            playbackOptionsByUrl[url] = media.Quality;
+                        }
+                    }
+                    else if (mediaJson.IsLive)
+                    {
+                        url = string.Empty;
+                        if (string.IsNullOrEmpty(media.Url))
+                        {
+                            string guessedStream = media.Server.Substring(media.Server.LastIndexOf('/') + 1);
+                            url = new MPUrlSourceFilter.RtmpUrl(media.Server) { Live = true, LiveStream = true, Subscribe = guessedStream, PageUrl = video.VideoUrl }.ToString();
+                        }
+                        else if (media.Url.Contains('?'))
+                        {
+                            var tcUrl = media.Server.TrimEnd('/') + media.Url.Substring(media.Url.IndexOf('?'));
+                            var app = new Uri(media.Server).AbsolutePath.Trim('/') + media.Url.Substring(media.Url.IndexOf('?'));
+                            var playPath = media.Url;
                             url = new MPUrlSourceFilter.RtmpUrl(tcUrl) { App = app, PlayPath = playPath, Live = true, PageUrl = video.VideoUrl, Subscribe = playPath }.ToString();
                         }
                         else
                         {
-                            url = new MPUrlSourceFilter.RtmpUrl(server + "/" + stream) { Live = true, LiveStream = true, Subscribe = stream, PageUrl = video.VideoUrl }.ToString();
+                            url = new MPUrlSourceFilter.RtmpUrl(media.Server + "/" + media.Url) { Live = true, LiveStream = true, Subscribe = media.Url, PageUrl = video.VideoUrl }.ToString();
                         }
-                        if (!video.PlaybackOptions.ContainsKey(quali)) video.PlaybackOptions[quali] = url;
+
+                        playbackOptionsByUrl[url] = media.Quality;
                     }
                 }
+
+                video.PlaybackOptions = new Dictionary<string, string>();
+                foreach (var lookup in playbackOptionsByUrl.ToLookup(kvp => kvp.Value))
+                {
+                    var i = 0;
+                    foreach(var optionByUrl in lookup)
+                    {
+                        video.PlaybackOptions.Add(string.Format("{0} - {1}", optionByUrl.Value, i++), optionByUrl.Key);
+                    }
+                }
+
             }
-            return video.PlaybackOptions.Select(p => p.Value).LastOrDefault();
+
+            string qualitytoMatch = videoQuality.ToString();
+            string firstUrl = video.PlaybackOptions.FirstOrDefault(p => p.Key.Contains(qualitytoMatch)).Value;
+            return !string.IsNullOrEmpty(firstUrl) ? firstUrl : video.PlaybackOptions.Select(kvp => kvp.Value).LastOrDefault();
         }
 
         string GetStreamUrlFromSmil(string smilUrl)

--- a/SiteUtilProjects/OnlineVideos.Sites.offbyone/WDRUtil.cs
+++ b/SiteUtilProjects/OnlineVideos.Sites.offbyone/WDRUtil.cs
@@ -15,6 +15,7 @@ namespace OnlineVideos.Sites
 		protected const string sendungenUrl = "http://www1.wdr.de/mediathek/video/sendungen-a-z/index.html";
         protected const string searchUrl = "http://www1.wdr.de/suche/index.jsp";
         protected const string livestreamUrl = "http://wdr_fs_geo-lh.akamaihd.net/z/wdrfs_geogeblockt@112044/manifest.f4m?b=608-&";
+        private string m3u8Regex = @"#EXT-X-STREAM-INF:PROGRAM-ID=\d,BANDWIDTH=(?<bitrate>\d+),RESOLUTION=(?<resolution>\d+x\d+),?CODECS=""(?<codecs>[^""]+)"".*?\n(?<url>.*)";
 
         public override int DiscoverDynamicCategories()
         {
@@ -32,7 +33,7 @@ namespace OnlineVideos.Sites
 			}
 
 			var shows = new List<RssLink>();
-            
+
             // add shows for current letter (A)
             FindCategories(doc, baseUri, shows);
 
@@ -46,7 +47,7 @@ namespace OnlineVideos.Sites
 					int o_i = (int)o;
 					var o_doc = GetWebData<HtmlDocument>(urls[o_i]);
 					// wait for the previous one to be loaded so we are in alphabetical order
-                    if (o_i > 0) 
+                    if (o_i > 0)
 						WaitHandle.WaitAny(new ManualResetEvent[] { threadWaitHandles[o_i - 1] });
 					FindCategories(o_doc, baseUri, shows);
 
@@ -66,14 +67,14 @@ namespace OnlineVideos.Sites
         public override List<VideoInfo> GetVideos(Category category)
         {
             if (category.Name == "Livestream")
-                return new List<VideoInfo>() { new VideoInfo() { Title = "Livestream", VideoUrl = "http://www1.wdr.de/mediathek/video/live/index.html" } };
+                return new List<VideoInfo>() { new VideoInfo() { Title = "Livestream", VideoUrl = "https://www1.wdr.de/mediathek/video/live/index.html" } };
             else
             {
                 var baseUri = new Uri(((RssLink)category).Url);
                 return getVideos(GetWebData<HtmlDocument>(baseUri.AbsoluteUri), baseUri);
             }
         }
-		
+
 		public override bool CanSearch { get { return true; } }
 
 		public override List<SearchResultItem> Search(string query, string category = null)
@@ -95,23 +96,50 @@ namespace OnlineVideos.Sites
                     Airdate = teaser.Descendants("p").First(p => p.GetAttributeValue("class", "") == "dachzeile").Element("a").LastChild.InnerText.Replace("vom", "").Trim()
                 });
             }
-            
+
             return result;
 		}
 
         public override string GetVideoUrl(VideoInfo video)
         {
             var doc = GetWebData<HtmlDocument>(video.VideoUrl);
-            var link = doc.DocumentNode.Descendants("a").FirstOrDefault(a => a.GetAttributeValue("data-extension", "").Contains("'url': 'http://"));
+            var link = doc.DocumentNode.Descendants("a").FirstOrDefault(a => a.GetAttributeValue("data-extension", "").Contains("\"url\":\"http"));
             if (link != null)
             {
                 var json = JObject.Parse(link.GetAttributeValue("data-extension", ""));
                 var playlistUrl = json["mediaObj"].Value<string>("url");
                 var f = GetWebData(playlistUrl);
-                var videoUrl = Regex.Match(f, "\"videoURL\":\"(?<url>.*?(f4m|smil))\"").Groups["url"].Value;
-                return (videoUrl.EndsWith("smil") ? GetStreamUrlFromSmil(videoUrl) + "&g=" : videoUrl + "?g=") + Helpers.StringUtils.GetRandomLetters(12) + "&hdcore=3.9.0";
-            }
+                var startIdx = f.IndexOf('{');
+                var endIdx = f.LastIndexOf('}');
+                var length = endIdx - startIdx + 1;
+                var json2 = JObject.Parse(f.Substring(startIdx, length));
+                var videoUrl = Regex.Match(f, "\"videoURL\":\"(?<url>.*?(f4m|smil|m3u8))\"").Groups["url"].Value;
+                var url = json2["mediaResource"]["alt"].Value<string>("videoURL");
 
+
+                var playbackOptionsByUrl = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (url.Contains("master.m3u8"))
+                {
+                    var uri = new Uri(new Uri(playlistUrl), url);
+                    var m3u8Data = GetWebData(uri.ToString());
+                    foreach (Match match in Regex.Matches(m3u8Data, m3u8Regex))
+                    {
+                        playbackOptionsByUrl[match.Groups["url"].Value] =
+                            string.Format("HLS - {0} - {1} kbps", match.Groups["resolution"].Value, int.Parse(match.Groups["bitrate"].Value) / 1000);
+                    }
+                }
+
+                video.PlaybackOptions = new Dictionary<string, string>();
+                foreach (var lookup in playbackOptionsByUrl.ToLookup(kvp => kvp.Value))
+                {
+                    var i = 0;
+                    foreach (var optionByUrl in lookup)
+                    {
+                        video.PlaybackOptions.Add(string.Format("{0} - {1}", optionByUrl.Value, i++), optionByUrl.Key);
+                    }
+                }
+                return video.PlaybackOptions.Select(p => p.Value).LastOrDefault();
+            }
             return null;
         }
 


### PR DESCRIPTION
Fix DasErste, WDR and ZDF Mediathek to new website layout and m3u8 parsing without touching onlinevideo.dll

See:
https://forum.team-mediaportal.com/threads/das-erste-livestream-not-working.137126